### PR TITLE
Fixed an edge case where negation scope overrides "positive" scope

### DIFF
--- a/lib/enumify/model.rb
+++ b/lib/enumify/model.rb
@@ -18,6 +18,7 @@ module Enumify
       self.class_eval do
 
         private
+
         define_method "_set_#{parameter.to_s}" do |value, should_save|
 
           value = value.to_sym
@@ -27,6 +28,7 @@ module Enumify
           send("#{parameter.to_s}_changed", old, value) if respond_to?("#{parameter.to_s}_changed", true) and old != value and !old.nil?
           return value
         end
+
       end
 
       opts.each do |opt|
@@ -40,15 +42,22 @@ module Enumify
             send("_set_#{parameter.to_s}", opt, true)
         end
 
-
         scope opt.to_sym, where(parameter.to_sym => opt.to_s)
+      end
+
+      # We want to first define all the "positive" scopes and only then define
+      # the "negation scopes", to make sure they don't override previous scopes
+      opts.each do |opt|
         # We need to prefix the field with the table name since if this scope will
         # be used in a joined query with other models that have the same enum field then
         # it will fail on ambiguous column name.
-        scope "not_#{opt}".to_sym, where("#{self.table_name}.#{parameter} != ?", opt.to_s)
+        unless respond_to?("not_#{opt}")
+          scope "not_#{opt}", where("#{self.table_name}.#{parameter} != ?", opt.to_s)
+        end
       end
 
     end
 
   end
+
 end

--- a/spec/enumify/enum_spec.rb
+++ b/spec/enumify/enum_spec.rb
@@ -11,7 +11,7 @@ class OtherModel < ActiveRecord::Base
 
   belongs_to :model
 
-  enum :status, [:active, :expired]
+  enum :status, [:active, :expired, :not_expired]
 end
 
 describe :Enumify do
@@ -26,6 +26,7 @@ describe :Enumify do
 
     @active_obj = OtherModel.create!(:status => :active, :model => @obj)
     @expired_obj = OtherModel.create!(:status => :expired, :model => @canceled_obj)
+    @not_expired_obj = OtherModel.create!(:status => :not_expired, :model => @canceled_obj)
   end
 
   describe "short hand methods" do
@@ -126,8 +127,16 @@ describe :Enumify do
       end
 
       it "should return objects that do not have the given value when joined with models who have the same enum field" do
-        OtherModel.joins(:model).not_active.should == [@expired_obj]
+        OtherModel.joins(:model).not_active.should include(@expired_obj, @not_expired_obj)
       end
+
+      it "should not override positive scopes" do
+        # We want here to verify that the not_expired scope return only the models with
+        # status == "not_expired" and not all the models with status != "expired",
+        # since negation scopes should not override the "positive" scopes.
+        OtherModel.not_expired.should == [@not_expired_obj]
+      end
+
     end
 
   end


### PR DESCRIPTION
- If an enum contains the values "available" and "not_available" then the negation scope will not override the regular "not_available" scope.

We need this fix to be able to use the new version of enumify (that contains the negation scope) in GoTogether .
